### PR TITLE
Fix typo

### DIFF
--- a/the-unix-command-language.md
+++ b/the-unix-command-language.md
@@ -247,7 +247,7 @@ goto loop
 is placed in a file, then the command
 
 <pre>
-sh &gt;file
+sh &lt;file
 </pre>
 
 will execute whatever is specified by *`command`* about every two


### PR DESCRIPTION
I guess this was a typo. Anyway, if the shell is supposed to execute commands from `file`, the correct syntax is `sh <file`, not `sh >file`. This is also the way this line appears in the pdf (see page 380 in the pdf's page numbering scheme). You might also want to recreate the html version, in case it is autogenerated from markdown.